### PR TITLE
removed lines for mysql driver workaround

### DIFF
--- a/internal/db/rules.go
+++ b/internal/db/rules.go
@@ -4,11 +4,10 @@ import (
 	"database/sql"
 	"fmt"
 
+	// Blank import required for mysql driver
+	_ "github.com/go-sql-driver/mysql"
 	"github.com/jimmyjames85/bouncecm/internal/models"
-	"github.com/go-sql-driver/mysql"
 )
-
-var _ = mysql.Open
 
 // ListRules - Function to pull all rules from db
 func ListRules() (models.RulesObject, error) {

--- a/internal/db/user.go
+++ b/internal/db/user.go
@@ -5,11 +5,10 @@ import (
 	"errors"
 	"fmt"
 
+	// Blank import required for mysql driver
+	_ "github.com/go-sql-driver/mysql"
 	"github.com/jimmyjames85/bouncecm/internal/models"
-	"github.com/go-sql-driver/mysql"
 )
-
-var _ = mysql.Open
 
 // GetUserByEmail - Function to pull user from db
 func GetUserByEmail(email string) ([]*models.User, error) {


### PR DESCRIPTION
# Summary
Removed 

`var _ = mysql.Open` in [internal/db/user.go](https://github.com/jimmyjames85/bouncecm/blob/master/internal/db/user.go) and [internal/db/rules.go](https://github.com/jimmyjames85/bouncecm/blob/master/internal/db/rules.go)

due to it causing issues when trying to run the server with `go run main.go`

## PR - Merge Checklist
- [x] CR'd
- [x] README updated or N/A
- [x] Fully tested and approved