### PR TITLE
[enum-fix] small change 'New' -> 'Create' in CreateChangelog

### DIFF
--- a/internal/sgbouncewizard/sgbouncewizard.go
+++ b/internal/sgbouncewizard/sgbouncewizard.go
@@ -190,7 +190,7 @@ func (srv *Server) DeleteRuleRoute(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
 	var toDelete models.ChangelogEntry
 	err := decoder.Decode(&toDelete)
-	
+
 	if err != nil {
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -199,9 +199,7 @@ func (srv *Server) DeleteRuleRoute(w http.ResponseWriter, r *http.Request) {
 
 	toDelete.Operation = "Delete"
 
-
 	err = srv.DBClient.CreateChangeLogEntry(toDelete.ID, &toDelete)
-
 
 	if err != nil {
 		log.Println(err)
@@ -209,15 +207,12 @@ func (srv *Server) DeleteRuleRoute(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-
 	err = srv.DBClient.DeleteRule(toDelete.ID)
 	if err != nil {
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
-
-
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -229,7 +224,7 @@ func (srv *Server) CreateRuleRoute(w http.ResponseWriter, r *http.Request) {
 	var rule models.ChangelogEntry
 
 	err := decoder.Decode(&rule)
-	rule.Operation = "New"
+	rule.Operation = "Create"
 	if err != nil {
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusBadRequest)


### PR DESCRIPTION
# Summary
Cleaned up one line that was missed in most recent update to master that addresses the operation from being 'New' to 'Create' in the changelog route

## PR - Merge Checklist
- [ ] CR'd
- [ ] README updated or N/A
- [ ] Fully tested and approved
